### PR TITLE
fix: thumbnail 등록시 window에서 이미지가 아닌 다른 확장자 등록 가능한 버그 수정

### DIFF
--- a/src/components/molecules/post/thumbnailContainer.tsx
+++ b/src/components/molecules/post/thumbnailContainer.tsx
@@ -75,6 +75,15 @@ const ThumbnailContainer = ({
       const file = files[0];
       const maxSize = 3 * 1024 * 1024;
 
+      // 허용된 이미지 형식 목록
+      const allowedTypes = ['image/jpeg', 'image/png', 'image/bmp'];
+
+      if (!allowedTypes.includes(file.type)) {
+        setFileUploadError('이미지 형식만 업로드 가능합니다.');
+        createToast('이미지 형식만 업로드 가능합니다.', 'warning');
+        return;
+      }
+
       if (file.size <= maxSize) {
         setFileUploadError(null);
         thumbnailMutate(file);


### PR DESCRIPTION
## 개요
thumbnail 등록시 window에서 이미지가 아닌 다른 확장자 등록 가능한 버그 수정

## 작업사항
- [ ] thumbnail 등록시 window에서 이미지가 아닌 다른 확장자 등록 가능한 버그 수정

## 관련 이슈
- [ ] close #206 
